### PR TITLE
Shortcode abstract class & first seven shortcodes

### DIFF
--- a/inc/class-shortcake-bakery.php
+++ b/inc/class-shortcake-bakery.php
@@ -1,0 +1,112 @@
+<?php
+
+class Shortcake_Bakery {
+
+	private $plugin_version;
+	private $plugin_dir;
+	private $plugin_url;
+
+	private static $instance;
+
+	public static function get_instance() {
+
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new self;
+			self::$instance->setup_actions();
+			self::$instance->register_shortcodes();
+		}
+
+		return self::$instance;
+	}
+
+	function __construct() {
+
+		$this->plugin_version 	= SHORTCAKE_BAKERY_VERSION;
+		$this->plugin_dir 		= plugin_dir_path( dirname( __FILE__ ) );
+		$this->plugin_url 		= plugin_dir_url( dirname( __FILE__ ) );
+
+	}
+
+	private function setup_actions() {
+
+	}
+
+	private function load_shortcode( $slug, $class ) {
+		$file = dirname( __FILE__ ) . '/shortcodes/class-' . $slug . '.php';
+
+		if ( file_exists( $file ) ) {
+			require_once $file;
+			if ( class_exists( $class ) ) {
+				new $class;
+			} // end if
+		} // end if
+	}
+
+	/**
+	 * Load generic shortcodes
+	 *
+	 * @param array $shortcodes The shortcodes [$slug => $class] array.
+	 */
+	private function load_shortcodes( $shortcodes = array() ) {
+		if ( ! is_array( $shortcodes ) ) {
+			return;
+		}
+		foreach ( $shortcodes as $slug => $class ) {
+			$this->load_shortcode( $slug, $class );
+		}
+	} // end function load_shortcodes
+
+	/**
+	 * Load theme-dependend shortcodes
+	 *
+	 * @param array $shortcodes The shortcodes [$slug => $class] array.
+	 */
+	private function load_theme_shortcodes( $shortcodes = array() ) {
+		if ( ! is_array( $shortcodes ) ) {
+			return;
+		}
+		foreach ( $shortcodes as $slug => $class ) {
+			if ( current_theme_supports( 'shortcode-' . $slug ) ) {
+				$this->load_shortcode( $slug, $class );
+			}
+		}
+	}
+
+	/**
+	 * Register the shortcodes and the UI for them.
+	 */
+	private function register_shortcodes() {
+
+		$shortcake_bakery_shortcodes = array(
+			'google-map'		=> 'Google_Map',
+			'heading'			=> 'Heading',
+		);
+		$shortcake_bakery_shortcodes = apply_filters(
+			'shortcake_bakery_shortcodes',
+			$shortcake_bakery_shortcodes
+		);
+
+		$shortcake_theme_shortcodes = array(
+			'bucket'			=> 'Bucket',
+			'mailing-address'	=> 'Mailing_Address',
+			'phone'				=> 'Phone',
+			'scroll-point'		=> 'Scroll_Point',
+		);
+		$shortcake_theme_shortcodes = apply_filters(
+			'shortcake_theme_shortcodes',
+			$shortcake_theme_shortcodes
+		);
+
+		require_once dirname( __FILE__ ) . '/class-shortcode.php';
+
+		$this->load_shortcodes( $shortcake_bakery_shortcodes );
+
+		$this->load_theme_shortcodes( $shortcake_theme_shortcodes );
+
+		if ( class_exists( 'Grunion_Contact_Form_Plugin' ) ) {
+			$this->load_shortcode( 'contact-field', 'Contact_Field' );
+		}
+
+	}
+
+}

--- a/inc/class-shortcode.php
+++ b/inc/class-shortcode.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * An abstract class for shortcode.
+ */
+abstract class Shortcode {
+
+	/**
+	 * Shortcode tag variable
+	 */
+	protected $shortcode_tag;
+
+	/**
+	 * List of supported attributes and their defaults
+	 */
+	protected $shortcode_attrs = array();
+
+	/**
+	 * Shortcode UI (Shortcake) arguments
+	 */
+	private $shortcake_args = array();
+
+	/**
+	 * Shortcode UI (Shortcake) attributes
+	 */
+	private $shortcake_attrs = array();
+
+	/**
+	 * Post Types
+	 */
+	private $post_type = array( 'post', 'page' );
+
+	/**
+	 * Shortcode class constructor
+	 *
+	 * @param string $shortcode_tag  Shortcode tag to be searched in post content.
+	 * @param array  $shortcake_args Optional, but recommended. List of Shortcake (Shortcode UI) tags.
+	 * @param bool   $add_shortcode  Optional. Whether the shortcode will be registered on WordPress.
+	 */
+	public function __construct( $shortcode_tag, $shortcake_args = array(), $add_shortcode = true ) {
+		$this->shortcode_tag 	= $shortcode_tag;
+		$this->shortcake_args 	= $shortcake_args;
+		if ( $add_shortcode ) {
+			$this->add_shortcode();
+		}
+		$this->shortcode_ui_register_for_shortcode();
+	}
+
+	/**
+	 * Adds an attribute to current Shortcode attribute slist
+	 *
+	 * @param string $attr 		Attribute name
+	 * @param mixed  $default 	Default value
+	 * @param array  $args 		Shortcake (Shortcode UI) args
+	 *
+	 */
+	public function add_attribute( $attr, $default = null, $args = array() ) {
+		if ( ! is_array( $this->shortcake_attrs ) ) {
+			$this->shortcake_attrs = array();
+		}
+
+		$this->shortcode_attrs[ $attr ] = apply_filters( $this->shortcode_tag . '_default_value', $default );
+		$args['attr'] = $attr;
+		$this->shortcake_attrs[] = $args;
+	}
+
+	/**
+	 * Add hook for shortcode tag
+	 *
+	 * There can only be one hook for each shortcode. Which means that if another
+	 * plugin has a similar shortcode, it will override yours or yours will override
+	 * theirs depending on which order the plugins are included and/or ran.
+	 *
+	 */
+	public function add_shortcode() {
+		do_action( 'before_add_shortcode_' . $this->shortcode_tag );
+		return \add_shortcode( $this->shortcode_tag, array( $this, 'callback' ) );
+	}
+
+	/**
+	 * Register the UI for the shortcode
+	 */
+	public function shortcode_ui_register_for_shortcode() {
+		if ( ! function_exists( 'shortcode_ui_register_for_shortcode' ) ) {
+			return;
+		}
+		$args = $this->shortcake_args;
+		$args['attrs'] = $this->shortcake_attrs;
+		return \shortcode_ui_register_for_shortcode( $this->shortcode_tag, $args );
+	}
+
+	/**
+	 * Render output from the shortcode.
+	 *
+	 * @param array $attrs Shortcode attributes.
+	 *
+	 * Don't forget to use ob_start() before and return ob_get_clean() after echoing code
+	 */
+	public function callback( $attrs = array(), $content = '' ) {
+		$this->shortcode_attrs = shortcode_atts(
+			$this->shortcode_attrs,
+			$attrs,
+			$this->shortcode_tag
+		);
+		ob_start();
+	}
+
+}

--- a/inc/shortcodes/class-bucket.php
+++ b/inc/shortcodes/class-bucket.php
@@ -1,0 +1,151 @@
+<?php
+
+class Bucket extends Shortcode {
+
+	public function __construct() {
+
+		$this->add_attribute( 'href', home_url(), array(
+			'label' 	=> _x( 'Link URL', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' 		=> 'url',
+			'meta' 		=> array(
+				'placeholder' => '//',
+			),
+		) );
+
+		$this->add_attribute( 'img_id', null, array(
+			'label' 	=> _x( 'Featured Image', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'description' => __( 'Use an image from your own site.', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' 		=> 'attachment',
+			'libraryType' => array( 'image' ),
+			'addButton' => _x( 'Select Image', 'Add Button', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'frameTitle' => _x( 'Select Image', 'Frame Title', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+		) );
+
+		/** This filter is documented in wp-admin/includes/media.php */
+		$sizes = apply_filters( 'image_size_names_choose', array(
+			'thumbnail' => _x( 'Thumbnail', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'medium'    => _x( 'Medium', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'large'     => _x( 'Large', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'full'      => _x( 'Full Size', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+		) );
+
+		$this->add_attribute( 'img_size', 'full', array(
+			'label' 	=> _x( 'Image Size', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' 		=> 'select',
+			'options' 	=> $sizes,
+		) );
+
+		$this->add_attribute( 'img_src', '', array(
+			'label' 	=> _x( 'External Image URL', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'description' => __( 'Use this field only if you want to use an external source image.', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' 		=> 'url',
+			'meta' 		=> array(
+				'placeholder' => '//',
+			),
+		) );
+
+		$this->add_attribute( 'img_width', 266, array(
+			'label' 	=> _x( 'Image Width', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' 		=> 'number',
+			'meta' 		=> array(
+				'min' 	=> 44,
+				'step' 	=> 1,
+			),
+		) );
+
+		$this->add_attribute( 'img_height', 94, array(
+			'label' 	=> _x( 'Image Height', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' 		=> 'number',
+			'meta' 		=> array(
+				'min' 	=> 44,
+				'step' 	=> 1,
+			),
+		) );
+
+		$this->add_attribute( 'class', '', array(
+			'label' 	=> __( 'CSS Class', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' 		=> 'text',
+		) );
+
+		$this->add_attribute( 'id', null, array(
+			'label' 	=> __( 'Numeric ID', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' 		=> 'number',
+			'meta' 		=> array(
+				'min' 	=> 1,
+				'step' 	=> 1,
+			),
+		) );
+
+		parent::__construct( 'bucket', array(
+			'label' 		=> _x( 'Bucket', 'Shortcode UI Label', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'listItemImage' => 'dashicons-align-left',
+			'inner_content' => array(
+				'label' => _x( 'Title', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			)
+		) );
+
+	} // end function __construct
+
+	public function callback( $atts = array(), $content = '' ) {
+		parent::callback( $atts, $content );
+
+		$img_id 	= $this->shortcode_attrs['img_id'];
+		$img_src 	= $this->shortcode_attrs['img_src'];
+
+		$use_local_img = isset( $img_id ) && ! empty( $img_id ) && intval( $img_id ) > 0;
+		$use_external_img = isset( $img_src ) && ! empty( $img_src ) && is_null( $img_id );
+
+		$id 		= $this->shortcode_attrs['id'];
+		$class 		= $this->shortcode_attrs['class'];
+		$href 		= $this->shortcode_attrs['href'];
+		$img_size 	= $this->shortcode_attrs['img_size'];
+		$img_width 	= $this->shortcode_attrs['img_width'];
+		$img_height = $this->shortcode_attrs['img_height'];
+
+		$image_args = array(
+	    	'alt' 	=> $content,
+	    	'class' => 'bucket-img bucket-img-' . intval( $id ) . ' wp-post-image',
+	    );
+
+		if ( isset( $img_height ) && ! empty( $img_height ) && intval( $img_height ) > 0 ) {
+			$image_args['height'] = intval( $img_height );
+		}
+
+		if ( $use_external_img ) {
+	    	$image_args['src'] 	  = $img_src;
+		}
+
+		if ( isset( $img_width ) && ! empty( $img_width ) && intval( $img_width ) > 0 ) {
+			$image_args['width']  = intval( $img_width );
+		}
+
+?>
+<div id="bucket<?php echo intval( $id ); ?>" class="bucket <?php echo esc_attr( $class ); ?>">
+    <a
+    	class="clickable"
+    	href="<?php echo esc_attr( $href ); ?>"
+    	title="<?php echo esc_attr( $content ); ?>">
+    </a>
+    <div class="featured-arrow"></div>
+	<div class="featured-title-area">
+      <h2><?php echo esc_html( $content ); ?></h2>
+    </div>
+    <div class="featured-image-area">
+    	<?php
+		if ( $use_local_img ) {
+			echo wp_get_attachment_image( intval( $img_id ), $img_size, false, $image_args );
+		}
+		else {
+?>
+<img <?php foreach ( $image_args as $key => $value ) { echo esc_attr( $key ) . '="' . esc_attr( $value ) . '" '; } ?> />
+<?php
+		}
+		?>
+    </div>
+</div>
+<?php
+		return ob_get_clean();
+
+	} // end function callback
+
+} // end class Bucket_Shortcode

--- a/inc/shortcodes/class-contact-field.php
+++ b/inc/shortcodes/class-contact-field.php
@@ -1,0 +1,41 @@
+<?php
+
+class Contact_Field extends Shortcode {
+
+	public function __construct() {
+
+		$this->add_attribute( 'label', '', array(
+			'label' 		=> _x( 'Field Label', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' 			=> 'text',
+		) );
+
+		$this->add_attribute( 'type', 'text', array(
+			'label' 		=> _x( 'Field Type', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'description' 	=> __( 'Accepted types: name, email, text, radio & select.', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type'  		=> 'select',
+			'options' 		=> array(
+				'name' 		=> _x( 'Name input', 'Field Type Option', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+				'email' 	=> _x( 'Email input', 'Field Type Option', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+				'text' 		=> _x( 'Text input', 'Field Type Option', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+				'radio' 	=> _x( 'Radio options', 'Field Type Option', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+				'select' 	=> _x( 'Select box', 'Field Type Option', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			),
+		) );
+
+		$this->add_attribute( 'required', '', array(
+			'label' 		=> _x( 'Required', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' 			=> 'select',
+			'options' 		=> array(
+				'' 			=> __( 'No', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+				'1' 		=> __( 'Yes', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			),
+		) );
+
+		parent::__construct( 'contact-field', array(
+			'label' 		=> _x( 'Contact Field', 'Shortcode UI Label', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'listItemImage' => 'dashicons-forms',
+		), false );
+
+	} // end function __construct
+
+} // end class Contact_Field

--- a/inc/shortcodes/class-google-map.php
+++ b/inc/shortcodes/class-google-map.php
@@ -1,0 +1,89 @@
+<?php
+
+class Google_Map extends Shortcode {
+
+	public function __construct() {
+
+		$this->add_attribute( 'q', '', array(
+			'label' 		=> _x( 'Map Query Address', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'description' 	=> _x( 'Example: 3785 Brickway Blvd., Santa Rosa, CA 95403', 'Map Query Address - Attribute Description', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' 			=> 'textarea',
+		) );
+
+		$this->add_attribute( 'z', 15, array(
+			'label' 		=> _x( 'Zoom', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'description' 	=> __( 'From 0 to 21. Default is 15.', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' 			=> 'number',
+			'meta' 			=> array(
+				'max' 		=> 21,
+				'min' 		=> 0,
+				'step' 		=> 1,
+			),
+		) );
+
+		$this->add_attribute( 'href', home_url(), array(
+			'label' 		=> _x( 'Link', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' 			=> 'url',
+			'meta' 			=> array(
+				'placeholder' => '//',
+			),
+		) );
+
+		parent::__construct( 'google_map', array(
+			'label' 		=> _x( 'Google Map', 'Shortcode UI Label', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'listItemImage' => 'dashicons-location-alt',
+		) );
+
+	} // end function __construct
+
+	/**
+	 * Build the map link
+	 *
+	 * Google map urls have lots of available params but zoom (z) and query (q) are enough.
+	 *
+	 * @param string $address Required. The map address.
+	 * @param int $zoom Optional. Map zoom. Default is 15.
+	 */
+	private function build_map_link( $address, $zoom = 15 ) {
+
+		$query_uri = 'http://maps.google.com/maps';
+		$params = array(
+			'q' => $this->urlencode_address( $address ),
+			'output' => 'embed',
+			'z' => $zoom,
+		);
+
+		return esc_url( add_query_arg( $params, $query_uri ) );
+	}
+
+	public function callback( $atts = array(), $content = '' ) {
+		parent::callback( $atts, $content );
+
+		$href = isset( $this->shortcode_attrs['href'] ) ? $this->shortcode_attrs['href'] : '#';
+		unset( $this->shortcode_attrs['href'] );
+
+		$embed_src = $this->build_map_link( $this->shortcode_attrs['q'], $this->shortcode_attrs['z'] );
+?>
+<a data-toggle="modal" href="<?php echo esc_attr( $href ); ?>" role="button">
+	<div id="mapContainer">
+    	<iframe src="<?php echo esc_url( $embed_src ); ?>">
+    		<?php echo esc_html( $this->shortcode_attrs['q'] ); ?>
+    	</iframe>
+    </div>
+</a>
+<?php
+		return ob_get_clean();
+
+	} // end function callback
+
+	private function urlencode_address( $address ) {
+
+		$address = strtolower( $address );
+		$address = preg_replace( '/\s+/', ' ', trim( $address ) ); // Get rid of any unwanted whitespace
+		$address = str_ireplace( ' ', '+', $address ); // Use + not %20
+		urlencode( $address );
+
+		return $address;
+	}
+
+} // end class Google_Map

--- a/inc/shortcodes/class-heading.php
+++ b/inc/shortcodes/class-heading.php
@@ -1,0 +1,42 @@
+<?php
+
+class Heading extends Shortcode {
+
+	public function __construct() {
+
+		$this->add_attribute( 'level', 2, array(
+			'label' 		=> _x( 'Heading Level', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'description' 	=> __( 'Heading level (from 1 to 6). Default is 2.', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' 			=> 'number',
+			'meta' 			=> array(
+				'max' 		=> 6,
+				'min' 		=> 1,
+				'step' 		=> 1,
+			),
+		) );
+
+		parent::__construct( 'heading', array(
+			'label' 		=> _x( 'Heading', 'Shortcode UI Label', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'listItemImage' => 'dashicons-editor-textcolor',
+			'inner_content' 	=> array(
+				'label' => __( 'Title', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			),
+		) );
+	}
+
+	public function callback( $atts = array(), $content = '' ) {
+		parent::callback( $atts, $content );
+
+		$level = $this->shortcode_attrs['level'];
+		$slug = sanitize_title( $content );
+
+		?>
+<h<?php echo intval( $level ); ?> id="<?php echo esc_attr( $slug ); ?>">
+	<a href="#<?php echo esc_attr( $slug ); ?>" title="<?php echo esc_attr( $content ); ?>">
+		<?php echo esc_html( $content ); ?>
+	</a>
+</h<?php echo intval( $level ); ?>><?php
+		return ob_get_clean();
+	}
+
+}

--- a/inc/shortcodes/class-mailing-address.php
+++ b/inc/shortcodes/class-mailing-address.php
@@ -1,0 +1,68 @@
+<?php
+
+class Mailing_Address extends Shortcode {
+
+	public function __construct() {
+
+		$this->add_attribute( 'title', _x( 'Mailing Address', 'Mailing Address Default Title', SHORTCAKE_BAKERY_TEXTDOMAIN ), array(
+			'label' => _x( 'Title', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' 	=> 'text',
+		) );
+
+		$this->add_attribute( 'street_address', '', array(
+			'label' => _x( 'Street Address', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'description' => _x( 'Example: 3785 Brickway Blvd.', 'Street Address Example', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' => 'text',
+		) );
+
+		$this->add_attribute( 'locality', '', array(
+			'label' => _x( 'Locality', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'description' => _x( 'Example: Santa Rosa', 'Locality Example', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' => 'text',
+		) );
+
+		$this->add_attribute( 'region', '', array(
+			'label' => _x( 'Region', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'description' => _x( 'Example: CA', 'Region Example', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' => 'text',
+		) );
+
+		$this->add_attribute( 'postal_code', '', array(
+			'label' => _x( 'Postal Code', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'description' => _x( 'Example: 95403', 'Postal Code Example', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' => 'text',
+		) );
+
+		parent::__construct( 'mailing_address', array(
+			'label' => _x( 'Mailing Address', 'Shortcode UI Label', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'listItemImage' => 'dashicons-location',
+			'inner_content' => array(
+				'label' => _x( 'Person or Business Name', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			),
+		) );
+
+	}
+
+	public function callback( $atts = array(), $content = '' ) {
+		parent::callback( $atts, $content );
+
+		$title 			= $this->shortcode_attrs['title'];
+		$street_address = $this->shortcode_attrs['street_address'];
+		$locality 		= $this->shortcode_attrs['locality'];
+		$region 		= $this->shortcode_attrs['region'];
+		$postal_code 	= $this->shortcode_attrs['postal_code'];
+?>
+<div id="mailing-address">
+    <i class="fa fa-map-marker"></i>
+    <?php echo esc_html( $title ); ?><br /><br />
+    <span><?php echo esc_html( $content ); ?></span><br />
+    <span class="street-address" itemprop="streetAddress"><?php echo esc_html( $street_address ); ?></span><br />
+    <span class="locality" itemprop="addressLocality"><?php echo esc_html( $locality ); ?></span>,
+    <abbr class="region" itemprop="addressRegion"><?php echo esc_html( $region ); ?></abbr>
+    <span class="postal-code"  itemprop="postalCode"><?php echo esc_html( $postal_code ); ?></span>
+</div>
+<?php
+		return ob_get_clean();
+	}
+
+}

--- a/inc/shortcodes/class-phone.php
+++ b/inc/shortcodes/class-phone.php
@@ -1,0 +1,78 @@
+<?php
+
+class Phone extends Shortcode {
+
+	public function __construct() {
+
+		$format = _x( 'Example: %s', 'Generic Attribute Description', SHORTCAKE_BAKERY_TEXTDOMAIN );
+
+		$this->add_attribute( 'type', 'phone', array(
+			'label' => _x( 'Phone Type', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' => 'radio',
+			'options' => array(
+				'phone' => _x( 'Phone', 'Phone Type Option', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+				'fax' 	=> _x( 'Fax', 'Phone Type Option', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			),
+		) );
+
+		$this->add_attribute( 'number', '', array(
+			'label' => _x( 'Phone Number', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'description' => _x( 'Example: 555-555-5555', 'Phone Number Description', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type'  => 'text',
+		) );
+
+		$default = _x( 'Phone:', 'Phone Shortcode Default Title', SHORTCAKE_BAKERY_TEXTDOMAIN );
+		$this->add_attribute( 'text', $default, array(
+			'label' => __( 'Text before number', 'shortcode-ui-essentials' ),
+			'description' => sprintf( $format, $default ),
+			'type' => 'text',
+			'meta' => array(
+				'placeholder' => $default,
+			),
+		) );
+
+		$default = _x( 'Call us today!', 'Phone Shortcode Default Tooltip', SHORTCAKE_BAKERY_TEXTDOMAIN );
+		$this->add_attribute( 'tooltip', $default, array(
+			'label' => _x( 'Link Tooltip', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'description' => sprintf( $format, $default ),
+			'type' => 'text',
+			'meta' => array(
+				'placeholder' => $default,
+			),
+		) );
+
+		parent::__construct( 'phone', array(
+			'label' => __( 'Phone', 'Shortcode UI Label', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'listItemImage' => 'dashicons-phone',
+		) );
+
+	}
+
+	public function callback( $atts = array(), $content = '' ) {
+		parent::callback( $atts, $content );
+
+		$type    = 'fax' === $this->shortcode_attrs['type'] ? 'fax' : 'phone';
+		$icon    = 'fax' === $type ? 'fa-print' : 'fa-mobile-phone';
+
+		$number  = $this->shortcode_attrs['number'];
+		$text    = $this->shortcode_attrs['text'];
+		$tooltip = $this->shortcode_attrs['tooltip'];
+?>
+<div id="<?php echo esc_attr( $type ); ?>-area">
+    <i class="fa <?php echo esc_attr( $icon ); ?>"></i>
+    <?php
+	echo esc_html( $text ) . '&nbsp;';
+	if ( 'phone' === $type ) {
+?>
+<a href="tel:<?php echo esc_attr( $number ); ?>" title="<?php echo esc_attr( $tooltip ); ?>" data-placement="bottom"><?php echo esc_html( $number ); ?></a>
+<?php
+	} else {
+		echo esc_html( $number ) . "\n";
+	}
+?>
+</div>
+<?php
+		return ob_get_clean();
+	}
+
+}

--- a/inc/shortcodes/class-scroll-point.php
+++ b/inc/shortcodes/class-scroll-point.php
@@ -1,0 +1,35 @@
+<?php
+
+class Scroll_Point extends Shortcode {
+
+	public function __construct() {
+
+		$this->add_attribute( 'id', null, array(
+			'label' => _x( 'ID', 'Attribute', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'type' 	=> 'number',
+			'meta' 	=> array(
+				'min'  => 1,
+				'step' => 1,
+			),
+		) );
+
+		parent::__construct( 'scroll_point', array(
+			'label' => _x( 'Scroll Point', 'Shortcode UI Label', SHORTCAKE_BAKERY_TEXTDOMAIN ),
+			'listItemImage' => 'dashicons-arrow-down',
+		) );
+
+	}
+
+	public function callback( $atts = array(), $content = '' ) {
+		parent::callback( $atts, $content );
+
+		$class = 'row-fluid';
+		$id = 'scroll-point-' . intval( $this->shortcode_attrs['id'] );
+?>
+<div class="<?php echo sanitize_html_class( $class ); ?> scroll-to-wrap" id="<?php echo esc_attr( $id ); ?>">
+	<span class="theme-arrow"></span>
+</div>
+<?php
+		return ob_get_clean();
+	}
+}

--- a/shortcake-bakery.php
+++ b/shortcake-bakery.php
@@ -1,12 +1,39 @@
 <?php
-/*
-Plugin Name: Shortcake Bakery
-Version: 0.1-alpha
-Description: PLUGIN DESCRIPTION HERE
-Author: YOUR NAME HERE
-Author URI: YOUR SITE HERE
-Plugin URI: PLUGIN SITE HERE
-Text Domain: shortcake-bakery
-Domain Path: /languages
+/**
+ * The Shortcake Bakery plugin file
+ *
+ * @link 		https://github.com/fusioneng/shortcake-bakery
+ * @since 		0.1-alpha
+ * @package 	Shortcake Bakery
+ *
+ * @wordpress-plugin
+ * Plugin Name: Shortcake Bakery
+ * Version: 	0.1-alpha
+ * Description: A fine selection of shortcodes for WordPress
+ * Author: 		Fusion Engineering and community
+ * Author URI: 	https://github.com/fusioneng
+ * Plugin URI: 	https://github.com/fusioneng/shortcake-bakery
+ * Text Domain: shortcake-bakery
+ * Domain Path: /languages
 */
 
+// If this file is called directly, abort.
+defined( 'WPINC' ) or die();
+define( 'SHORTCAKE_BAKERY_TEXTDOMAIN', 'shortcake-bakery' );
+define( 'SHORTCAKE_BAKERY_VERSION', '0.1-alpha' );
+
+/**
+ * The core plugin class
+ */
+require_once dirname( __FILE__ ) . '/inc/class-shortcake-bakery.php';
+
+/**
+ * Begins execution of the plugin.
+ *
+ * @since    0.1-alpha
+ */
+function run_shortcake_bakery() {
+	$shortcake_bakery = Shortcake_Bakery::get_instance();
+}
+
+add_action( 'init', 'run_shortcake_bakery', 5 );


### PR DESCRIPTION
* Extend the Shortcode class to quickly register a macro in WordPress
Core and Shortcode UI. Use it in your own plugin or theme (plugin is
better);
* Brand new generic shortcodes: Google Map (no API key needed) and HTML
Heading;
* Brand new template-dependent shortcakes: Bucket, Mailing Address,
Phone & Scroll Point (need add_theme_support to work);
* Improved plugin header file.