### PR TITLE
Add new acceptable pattern for FB embed/URL

### DIFF
--- a/tests/test-facebook-shortcode.php
+++ b/tests/test-facebook-shortcode.php
@@ -14,6 +14,12 @@ class Test_Facebook_Shortcode extends WP_UnitTestCase {
 		$this->assertContains( '<div class="fb-post shortcake-bakery-responsive" data-href="https://www.facebook.com/video.php?v=1095405247152119"', apply_filters( 'the_content', $post->post_content ) );
 	}
 
+	public function test_pretty_permalink_video_display() {
+		$post_id = $this->factory->post->create( array( 'post_content' => '[facebook url="https://www.facebook.com/coreycf/videos/953479961370562/"]' ) );
+		$post = get_post( $post_id );
+		$this->assertContains( '<div class="fb-post shortcake-bakery-responsive" data-href="https://www.facebook.com/coreycf/videos/953479961370562/"', apply_filters( 'the_content', $post->post_content ) );
+	}
+
 	public function test_embed_reversal() {
 		$old_content = <<<EOT
 

--- a/tests/test-facebook-shortcode.php
+++ b/tests/test-facebook-shortcode.php
@@ -31,4 +31,21 @@ EOT;
 
 	}
 
+	public function test_video_embed_reversal() {
+		$old_content = <<<EOT
+
+		apples before
+
+		<div id="fb-root"></div><script>(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.3"; fjs.parentNode.insertBefore(js, fjs);}(document, 'script', 'facebook-jssdk'));</script><div class="fb-video" data-allowfullscreen="1" data-href="/coreycf/videos/vb.100001257008891/953479961370562/?type=1"><div class="fb-xfbml-parse-ignore"><blockquote cite="/coreycf/videos/953479961370562/"><a href="/coreycf/videos/953479961370562/"></a><p>Here&#039;s the free styling he put on lol Brent John Janis Franklin Sioux Bob Nate Badmilk</p>Posted by <a href="https://www.facebook.com/coreycf">Corey James</a> on Saturday, June 27, 2015</blockquote></div></div>
+
+		bananas after
+EOT;
+		$transformed_content = wp_filter_post_kses( $old_content );
+		$transformed_content = str_replace( '\"', '"', $transformed_content ); // Kses slashes the data
+		$this->assertContains( '[facebook url="https://www.facebook.com/coreycf/videos/953479961370562/"]', $transformed_content );
+		$this->assertContains( 'apples before', $transformed_content );
+		$this->assertContains( 'bananas after', $transformed_content );
+
+	}
+
 }


### PR DESCRIPTION
See https://github.com/fusioneng/shortcake-bakery/issues/33

Adds new pattern to `reversal` and `callback` functions to recognize Facebook video URL's in the pattern: `https://www.facebook.com/coreycf/videos/953479961370562/`

![screen shot 2015-06-30 at 2 58 45 pm](https://cloud.githubusercontent.com/assets/1636964/8439270/efa3ced2-1f38-11e5-9fce-de1488cd2513.png)