### PR TITLE
Ensure Vine embed reversal works with trailing `&nbsp;`

### DIFF
--- a/inc/shortcodes/class-vine.php
+++ b/inc/shortcodes/class-vine.php
@@ -21,7 +21,7 @@ class Vine extends Shortcode {
 
 	public static function reversal( $content ) {
 
-		$needle = '#<iframe[^>]+src="https?://vine\.co/v/([\w]+)(/[^"]+)?"[^>]+></iframe>#';
+		$needle = '#<iframe[^>]+src="https?://vine\.co/v/([\w]+)(/[^"]+)?"[^>]+>(</iframe>)?#';
 		if ( preg_match_all( $needle, $content, $matches ) ) {
 			$replacements = array();
 			$shortcode_tag = self::get_shortcode_tag();

--- a/tests/test-vine-shortcode.php
+++ b/tests/test-vine-shortcode.php
@@ -36,9 +36,9 @@ EOT;
 		$this->assertEquals( $expected_content, $transformed_content );
 	}
 
-	public function test_embed_reversal_with_trailing_nbsp() {
+	public function test_embed_reversal_with_no_closing_tag_and_trailing_nbsp() {
 		$old_content = '<iframe src="https://vine.co/v/eMnmixYtwr1/embed/simple" width="300" height="300" frameborder="0">&nbsp;';
-		$expected_content = '[vine url="https://vine.co/v/eMnmixYtwr1"]';
+		$expected_content = '[vine url="https://vine.co/v/eMnmixYtwr1"]&nbsp;';
 		$transformed_content = wp_filter_post_kses( $old_content );
 		$transformed_content = str_replace( '\"', '"', $transformed_content ); // Kses slashes the data
 		$this->assertEquals( $expected_content, $transformed_content );

--- a/tests/test-vine-shortcode.php
+++ b/tests/test-vine-shortcode.php
@@ -36,4 +36,12 @@ EOT;
 		$this->assertEquals( $expected_content, $transformed_content );
 	}
 
+	public function test_embed_reversal_with_trailing_nbsp() {
+		$old_content = '<iframe src="https://vine.co/v/eMnmixYtwr1/embed/simple" width="300" height="300" frameborder="0">&nbsp;';
+		$expected_content = '[vine url="https://vine.co/v/eMnmixYtwr1"]';
+		$transformed_content = wp_filter_post_kses( $old_content );
+		$transformed_content = str_replace( '\"', '"', $transformed_content ); // Kses slashes the data
+		$this->assertEquals( $expected_content, $transformed_content );
+	}
+
 }


### PR DESCRIPTION
See #83