### PR TITLE
Abstract `parse_iframes` to parse content for any arbitrary tag

### DIFF
--- a/inc/shortcodes/class-shortcode.php
+++ b/inc/shortcodes/class-shortcode.php
@@ -62,7 +62,7 @@ abstract class Shortcode {
 	 * @param string $tag_name
 	 * @return array|false
 	 */
-	protected static function parse_closed_tags( $content, $tag_name ) {
+	private static function parse_closed_tags( $content, $tag_name ) {
 
 		if ( false === stripos( $content, '<' . $tag_name ) ) {
 			return false;

--- a/tests/class-shortcode.php
+++ b/tests/class-shortcode.php
@@ -6,6 +6,10 @@ class Shortcode extends Shortcake_Bakery\Shortcodes\Shortcode {
 		return parent::parse_iframes( $content );
 	}
 
+	public static function parse_script_tags( $content ) {
+		return parent::parse_script_tags( $content );
+	}
+
 	public static function make_replacements_to_content( $content, $replacements ) {
 		return parent::make_replacements_to_content( $content, $replacements );
 	}

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -95,6 +95,24 @@ EOT;
 		$this->assertEquals( $iframe_obj, $parsed[0] );
 	}
 
+	public function test_parse_script_tags() {
+		$script_str = '<div id="wsd-root"></div>' . "\r\n" .
+			'<script type="text/javascript" src="http://script-domain.net/assets/js/widget.js?id=3"></script>';
+		$parsed = Shortcode::parse_script_tags( $script_str );
+		$expected = (object) array(
+			'original' => '<script type="text/javascript" src="http://script-domain.net/assets/js/widget.js?id=3"></script>',
+			'before' => '<div id="wsd-root"></div>' . "\r\n",
+			'after' => '',
+			'inner' => '',
+			'src_force_protocol' => 'http://script-domain.net/assets/js/widget.js?id=3',
+			'attrs' => array(
+				'type' => 'text/javascript',
+				'src' =>  'http://script-domain.net/assets/js/widget.js?id=3'
+			)
+		);
+		$this->assertEquals( $expected, $parsed[0] );
+	}
+
 	public function test_make_replacements_to_content() {
 		$original_content = <<<EOT
 monkey see

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -107,8 +107,8 @@ EOT;
 			'src_force_protocol' => 'http://script-domain.net/assets/js/widget.js?id=3',
 			'attrs' => array(
 				'type' => 'text/javascript',
-				'src' => 'http://script-domain.net/assets/js/widget.js?id=3'
-			)
+				'src' => 'http://script-domain.net/assets/js/widget.js?id=3',
+			),
 		);
 		$this->assertEquals( $expected, $parsed[0] );
 	}

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -107,7 +107,7 @@ EOT;
 			'src_force_protocol' => 'http://script-domain.net/assets/js/widget.js?id=3',
 			'attrs' => array(
 				'type' => 'text/javascript',
-				'src' =>  'http://script-domain.net/assets/js/widget.js?id=3'
+				'src' => 'http://script-domain.net/assets/js/widget.js?id=3'
 			)
 		);
 		$this->assertEquals( $expected, $parsed[0] );


### PR DESCRIPTION
Expands the abstraction from `Shortcode::parse_iframes` so that it can be used to parse for other tags, like `<script`, in doing shortcode reversals.