### PR TITLE
Rename `parse_script_tags()` to `parse_scripts()`

### DIFF
--- a/inc/shortcodes/class-shortcode.php
+++ b/inc/shortcodes/class-shortcode.php
@@ -109,7 +109,7 @@ abstract class Shortcode {
 	 * @param string $content
 	 * @return array|false
 	 */
-	protected static function parse_script_tags( $content ) {
+	protected static function parse_scripts( $content ) {
 		return self::parse_closed_tags( $content, 'script' );
 	}
 

--- a/tests/class-shortcode.php
+++ b/tests/class-shortcode.php
@@ -6,8 +6,8 @@ class Shortcode extends Shortcake_Bakery\Shortcodes\Shortcode {
 		return parent::parse_iframes( $content );
 	}
 
-	public static function parse_script_tags( $content ) {
-		return parent::parse_script_tags( $content );
+	public static function parse_scripts( $content ) {
+		return parent::parse_scripts( $content );
 	}
 
 	public static function make_replacements_to_content( $content, $replacements ) {

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -95,10 +95,10 @@ EOT;
 		$this->assertEquals( $iframe_obj, $parsed[0] );
 	}
 
-	public function test_parse_script_tags() {
+	public function test_parse_scripts() {
 		$script_str = '<div id="wsd-root"></div>' . "\r\n" .
 			'<script type="text/javascript" src="http://script-domain.net/assets/js/widget.js?id=3"></script>';
-		$parsed = Shortcode::parse_script_tags( $script_str );
+		$parsed = Shortcode::parse_scripts( $script_str );
 		$expected = (object) array(
 			'original' => '<script type="text/javascript" src="http://script-domain.net/assets/js/widget.js?id=3"></script>',
 			'before' => '<div id="wsd-root"></div>' . "\r\n",


### PR DESCRIPTION
It's more consistent with `parse_iframes()`

See #98