### PR TITLE
Transform protocol-less `src` to `https` instead of `http`

### DIFF
--- a/inc/shortcodes/class-shortcode.php
+++ b/inc/shortcodes/class-shortcode.php
@@ -81,7 +81,7 @@ abstract class Shortcode {
 
 				// Use src_force_protocol with parse_url() in PHP 5.3
 				if ( ! empty( $tag->attrs['src'] ) ) {
-					$tag->src_force_protocol = 0 === strpos( $tag->attrs['src'], '//' ) ? 'http:' . $tag->attrs['src'] : $tag->attrs['src'];
+					$tag->src_force_protocol = 0 === strpos( $tag->attrs['src'], '//' ) ? 'https:' . $tag->attrs['src'] : $tag->attrs['src'];
 				} else {
 					$tag->src_force_protocol = '';
 				}

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -70,7 +70,7 @@ EOT;
 		$iframe_obj->before = '';
 		$iframe_obj->after = '<p><a href="http://giphy.com/gifs/jtvedit-jtv-rogelio-de-la-vega-ihfrhIgdkQ83C">via GIPHY</a></p>';
 		$iframe_obj->inner = '';
-		$iframe_obj->src_force_protocol = 'http://giphy.com/embed/ihfrhIgdkQ83C';
+		$iframe_obj->src_force_protocol = 'https://giphy.com/embed/ihfrhIgdkQ83C';
 		$iframe_obj->attrs = array(
 			'src'             => '//giphy.com/embed/ihfrhIgdkQ83C',
 			'width'           => '480',

--- a/tests/test-silk-shortcode.php
+++ b/tests/test-silk-shortcode.php
@@ -21,7 +21,7 @@ EOT;
 
 		apples before
 
-		[silk url="http://us-states-with-hiv-specific-criminal-laws.silk.co/s/embed/map/collection/states-with-hiv-specific-criminal-laws-1/location/title/on/silk.co/order/asc/states-with-hiv-specific-criminal-law"]
+		[silk url="https://us-states-with-hiv-specific-criminal-laws.silk.co/s/embed/map/collection/states-with-hiv-specific-criminal-laws-1/location/title/on/silk.co/order/asc/states-with-hiv-specific-criminal-law"]
 
 		bananas after
 EOT;


### PR DESCRIPTION
If we're provided a protocol-less URL, we can safely assume it supports https

See #107