### PR TITLE
Deprecate `src_force_protocol` attribute in favor of 5.3 compat

### DIFF
--- a/inc/shortcodes/class-abc-news.php
+++ b/inc/shortcodes/class-abc-news.php
@@ -26,7 +26,7 @@ class ABC_News extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( ! in_array( parse_url( $iframe->src_force_protocol, PHP_URL_HOST ), self::$valid_hosts ) ) {
+				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), self::$valid_hosts ) ) {
 					continue;
 				}
 				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( $iframe->attrs['src'] ) . '"]';
@@ -39,7 +39,7 @@ class ABC_News extends Shortcode {
 
 	public static function callback( $attrs, $content = '' ) {
 
-		if ( empty( $attrs['url'] ) || ! in_array( parse_url( $attrs['url'], PHP_URL_HOST ), self::$valid_hosts ) ) {
+		if ( empty( $attrs['url'] ) || ! in_array( self::parse_url( $attrs['url'], PHP_URL_HOST ), self::$valid_hosts ) ) {
 			return '';
 		}
 

--- a/inc/shortcodes/class-flickr.php
+++ b/inc/shortcodes/class-flickr.php
@@ -26,10 +26,10 @@ class Flickr extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( ! in_array( parse_url( $iframe->src_force_protocol, PHP_URL_HOST ), self::$valid_hosts ) ) {
+				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), self::$valid_hosts ) ) {
 					continue;
 				}
-				$url = preg_replace( '#/player/?$#', '/', $iframe->src_force_protocol );
+				$url = preg_replace( '#/player/?$#', '/', $iframe->attrs['src'] );
 				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( $url ) . '"]';
 			}
 			$content = self::make_replacements_to_content( $content, $replacements );
@@ -40,7 +40,7 @@ class Flickr extends Shortcode {
 
 	public static function callback( $attrs, $content = '' ) {
 
-		if ( empty( $attrs['url'] ) || ! in_array( parse_url( $attrs['url'], PHP_URL_HOST ), self::$valid_hosts ) ) {
+		if ( empty( $attrs['url'] ) || ! in_array( self::parse_url( $attrs['url'], PHP_URL_HOST ), self::$valid_hosts ) ) {
 			return '';
 		}
 

--- a/inc/shortcodes/class-giphy.php
+++ b/inc/shortcodes/class-giphy.php
@@ -24,11 +24,11 @@ class Giphy extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( 'giphy.com' !== parse_url( $iframe->src_force_protocol, PHP_URL_HOST ) ) {
+				if ( 'giphy.com' !== self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ) ) {
 					continue;
 				}
 				// Embed ID is the last part of the URL
-				$parts = explode( '/', trim( parse_url( $iframe->src_force_protocol, PHP_URL_PATH ), '/' ) );
+				$parts = explode( '/', trim( self::parse_url( $iframe->attrs['src'], PHP_URL_PATH ), '/' ) );
 				$embed_id = array_pop( $parts );
 				$replacement_key = $iframe->original;
 				// GIPHY embeds can append <p><a href="http://giphy.com/gifs/jtvedit-jtv-rogelio-de-la-vega-ihfrhIgdkQ83C">via GIPHY</a></p>
@@ -45,7 +45,7 @@ class Giphy extends Shortcode {
 
 	public static function callback( $attrs, $content = '' ) {
 
-		if ( empty( $attrs['url'] ) || 'giphy.com' !== parse_url( $attrs['url'], PHP_URL_HOST ) ) {
+		if ( empty( $attrs['url'] ) || 'giphy.com' !== self::parse_url( $attrs['url'], PHP_URL_HOST ) ) {
 			return '';
 		}
 

--- a/inc/shortcodes/class-guardian.php
+++ b/inc/shortcodes/class-guardian.php
@@ -24,10 +24,10 @@ class Guardian extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( ! in_array( parse_url( $iframe->src_force_protocol, PHP_URL_HOST ), array( 'embed.theguardian.com' ) ) ) {
+				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), array( 'embed.theguardian.com' ) ) ) {
 					continue;
 				}
-				$path = parse_url( $iframe->src_force_protocol, PHP_URL_PATH );
+				$path = self::parse_url( $iframe->attrs['src'], PHP_URL_PATH );
 				$url = 'http://www.theguardian.com' . preg_replace( '#^/embed/video/#', '/', $path );
 				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( $url ) . '"]';
 			}
@@ -39,11 +39,11 @@ class Guardian extends Shortcode {
 
 	public static function callback( $attrs, $content = '' ) {
 
-		if ( empty( $attrs['url'] ) || ! in_array( parse_url( $attrs['url'], PHP_URL_HOST ), array( 'theguardian.com', 'www.theguardian.com' ) ) ) {
+		if ( empty( $attrs['url'] ) || ! in_array( self::parse_url( $attrs['url'], PHP_URL_HOST ), array( 'theguardian.com', 'www.theguardian.com' ) ) ) {
 			return '';
 		}
 
-		$path = parse_url( $attrs['url'], PHP_URL_PATH );
+		$path = self::parse_url( $attrs['url'], PHP_URL_PATH );
 		$url = 'https://embed.theguardian.com/embed/video' . $path;
 		return sprintf( '<iframe class="shortcake-bakery-responsive" width="560" height="315" src="%s" frameborder="0"></iframe>', esc_url( $url ) );
 	}

--- a/inc/shortcodes/class-iframe.php
+++ b/inc/shortcodes/class-iframe.php
@@ -61,7 +61,7 @@ class Iframe extends Shortcode {
 			$whitelisted_iframe_domains = static::get_whitelisted_iframe_domains();
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( ! in_array( parse_url( $iframe->src_force_protocol, PHP_URL_HOST ), $whitelisted_iframe_domains ) ) {
+				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), $whitelisted_iframe_domains ) ) {
 					continue;
 				}
 				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' src="' . esc_url_raw( $iframe->attrs['src'] ) . '"]';
@@ -85,8 +85,7 @@ class Iframe extends Shortcode {
 		$attrs = array_merge( $defaults, $attrs );
 		$whitelisted_iframe_domains = static::get_whitelisted_iframe_domains();
 
-		$url_for_parse = ( 0 === strpos( $attrs['src'], '//' ) ) ? 'http:' . $attrs['src'] :  $attrs['src'];
-		$host = parse_url( $url_for_parse, PHP_URL_HOST );
+		$host = self::parse_url( $attrs['src'], PHP_URL_HOST );
 		if ( ! in_array( $host, $whitelisted_iframe_domains ) ) {
 			return '';
 		}

--- a/inc/shortcodes/class-infogram.php
+++ b/inc/shortcodes/class-infogram.php
@@ -36,7 +36,7 @@ class Infogram extends Shortcode
 		if ( $scripts = self::parse_scripts( $content ) ) {
 			$replacements = array();
 			foreach ( $scripts as $script ) {
-				if ( 'e.infogr.am' !== parse_url( $script->src_force_protocol, PHP_URL_HOST ) ) {
+				if ( 'e.infogr.am' !== self::parse_url( $script->attrs['src'], PHP_URL_HOST ) ) {
 					continue;
 				}
 				if ( empty( $script->attrs['id'] ) ) {
@@ -50,10 +50,10 @@ class Infogram extends Shortcode
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( 'e.infogr.am' !== parse_url( $iframe->src_force_protocol, PHP_URL_HOST ) ) {
+				if ( 'e.infogr.am' !== self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ) ) {
 					continue;
 				}
-				$url_string = ltrim( parse_url( $iframe->src_force_protocol, PHP_URL_PATH ), '/' );
+				$url_string = ltrim( self::parse_url( $iframe->attrs['src'], PHP_URL_PATH ), '/' );
 				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url( 'https://infogr.am/' . $url_string ) . '"]';
 			}
 			$content = self::make_replacements_to_content( $content, $replacements );

--- a/inc/shortcodes/class-instagram.php
+++ b/inc/shortcodes/class-instagram.php
@@ -38,10 +38,10 @@ class Instagram extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( 'instagram.com' !== parse_url( $iframe->src_force_protocol, PHP_URL_HOST ) ) {
+				if ( 'instagram.com' !== self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ) ) {
 					continue;
 				}
-				if ( preg_match( '#//instagram\.com/p/([^/]+)/embed/?#', $iframe->src_force_protocol, $matches ) ) {
+				if ( preg_match( '#//instagram\.com/p/([^/]+)/embed/?#', $iframe->attrs['src'], $matches ) ) {
 					$embed_id = $matches[1];
 				} else {
 					continue;

--- a/inc/shortcodes/class-livestream.php
+++ b/inc/shortcodes/class-livestream.php
@@ -26,11 +26,11 @@ class Livestream extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( ! in_array( parse_url( $iframe->src_force_protocol, PHP_URL_HOST ), self::$valid_hosts ) ) {
+				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), self::$valid_hosts ) ) {
 					continue;
 				}
 				// URL looks like: http://new.livestream.com/accounts/9035483/events/3424523/videos/64460770/player?width=480&height=270&autoPlay=false&mute=false
-				$path = parse_url( $iframe->src_force_protocol, PHP_URL_PATH );
+				$path = self::parse_url( $iframe->attrs['src'], PHP_URL_PATH );
 				$path = preg_replace( '#/player/?$#', '/', $path );
 				$url = 'https://livestream.com' . $path;
 				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( $url ) . '"]';
@@ -42,7 +42,7 @@ class Livestream extends Shortcode {
 
 	public static function callback( $attrs, $content = '' ) {
 
-		if ( empty( $attrs['url'] ) || ! in_array( parse_url( $attrs['url'], PHP_URL_HOST ), self::$valid_hosts ) ) {
+		if ( empty( $attrs['url'] ) || ! in_array( self::parse_url( $attrs['url'], PHP_URL_HOST ), self::$valid_hosts ) ) {
 			return '';
 		}
 

--- a/inc/shortcodes/class-playbuzz.php
+++ b/inc/shortcodes/class-playbuzz.php
@@ -98,7 +98,7 @@ class Playbuzz extends Shortcode {
 		}
 
 		$playbuzz_args = array(
-			'game'     => parse_url( $attrs['url'], PHP_URL_PATH ),
+			'game'     => self::parse_url( $attrs['url'], PHP_URL_PATH ),
 			'height'   => 'auto',
 			);
 

--- a/inc/shortcodes/class-rap-genius.php
+++ b/inc/shortcodes/class-rap-genius.php
@@ -26,7 +26,7 @@ class Rap_Genius extends Shortcode {
 		if ( $scripts = self::parse_scripts( $content ) ) {
 			$replacements = array();
 			foreach ( $scripts as $script ) {
-				if ( 'genius.codes' !== parse_url( $script->src_force_protocol, PHP_URL_HOST ) ) {
+				if ( 'genius.codes' !== self::parse_url( $script->attrs['src'], PHP_URL_HOST ) ) {
 					continue;
 				}
 				$replacements[ $script->original ] = '[' . self::get_shortcode_tag() . ']';

--- a/inc/shortcodes/class-scribd.php
+++ b/inc/shortcodes/class-scribd.php
@@ -24,11 +24,11 @@ class Scribd extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( ! in_array( parse_url( $iframe->src_force_protocol, PHP_URL_HOST ), array( 'www.scribd.com', 'scribd.com' ) ) ) {
+				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), array( 'www.scribd.com', 'scribd.com' ) ) ) {
 					continue;
 				}
 				// URL looks like: https://www.scribd.com/embeds/272220183/content?start_page=1&amp;view_mode=scroll&amp;show_recommendations=true
-				$url = explode( 'content?', $iframe->src_force_protocol );
+				$url = explode( 'content?', $iframe->attrs['src'] );
 				$url = str_replace( '/embeds/', '/doc/', $url[0] );
 				$replacements[ $iframe->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( $url ) . '"]';
 			}

--- a/inc/shortcodes/class-script.php
+++ b/inc/shortcodes/class-script.php
@@ -38,7 +38,7 @@ class Script extends Shortcode {
 			$whitelisted_script_domains = static::get_whitelisted_script_domains();
 			$shortcode_tag = static::get_shortcode_tag();
 			foreach ( $scripts as $script ) {
-				$host = parse_url( $script->src_force_protocol, PHP_URL_HOST );
+				$host = self::parse_url( $script->attrs['src'], PHP_URL_HOST );
 				if ( ! in_array( $host, $whitelisted_script_domains ) ) {
 					continue;
 				}
@@ -55,8 +55,7 @@ class Script extends Shortcode {
 			return '';
 		}
 
-		$url_for_parse = ( 0 === strpos( $attrs['src'], '//' ) ) ? 'http:' . $attrs['src'] :  $attrs['src'];
-		$host = parse_url( $url_for_parse, PHP_URL_HOST );
+		$host = self::parse_url( $attrs['src'], PHP_URL_HOST );
 
 		if ( ! in_array( $host, static::get_whitelisted_script_domains() ) ) {
 			if ( current_user_can( 'edit_posts' ) ) {

--- a/inc/shortcodes/class-shortcode.php
+++ b/inc/shortcodes/class-shortcode.php
@@ -56,6 +56,30 @@ abstract class Shortcode {
 	}
 
 	/**
+	 * parse_url(), fully-compatible with protocol-less URLs and PHP 5.3
+	 *
+	 * @param string $url
+	 * @param int $component
+	 * @return mixed
+	 */
+	protected static function parse_url( $url, $component = -1 ) {
+		$added_protocol = false;
+		if ( 0 === strpos( $url, '//' ) ) {
+			$url = 'http:' . $url;
+			$added_protocol = true;
+		}
+		$ret = parse_url( $url, $component );
+		if ( $added_protocol && $ret ) {
+			if ( -1 === $component && isset( $ret['scheme'] ) ) {
+				unset( $ret['scheme'] );
+			} else if ( PHP_URL_SCHEME === $component ) {
+				$ret = '';
+			}
+		}
+		return $ret;
+	}
+
+	/**
 	 * Parse a string of content for a given tag name.
 	 *
 	 * @param string $content
@@ -78,13 +102,6 @@ abstract class Shortcode {
 				$tag->inner = $matches[4][ $key ];
 				$tag->after = $matches[5][ $key ];
 				$tag->attrs = self::parse_tag_attributes( $matches[3][ $key ] );
-
-				// Use src_force_protocol with parse_url() in PHP 5.3
-				if ( ! empty( $tag->attrs['src'] ) ) {
-					$tag->src_force_protocol = 0 === strpos( $tag->attrs['src'], '//' ) ? 'http:' . $tag->attrs['src'] : $tag->attrs['src'];
-				} else {
-					$tag->src_force_protocol = '';
-				}
 				$tags[] = $tag;
 			}
 			return $tags;

--- a/inc/shortcodes/class-silk.php
+++ b/inc/shortcodes/class-silk.php
@@ -35,7 +35,7 @@ class Silk extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( 'silk.co' !== self::get_tld_from_url( $iframe->src_force_protocol, PHP_URL_HOST ) ) {
+				if ( 'silk.co' !== self::get_tld_from_url( $iframe->attrs['src'] ) ) {
 					continue;
 				}
 				$replacement_key = $iframe->original;
@@ -43,7 +43,7 @@ class Silk extends Shortcode {
 				if ( false !== strpos( $iframe->after, 'Data from <a target' ) ) {
 					$replacement_key .= $iframe->after;
 				}
-				$replacements[ $replacement_key ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( $iframe->src_force_protocol ) . '"]';
+				$replacements[ $replacement_key ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( $iframe->attrs['src'] ) . '"]';
 			}
 			$content = self::make_replacements_to_content( $content, $replacements );
 		}
@@ -85,7 +85,7 @@ class Silk extends Shortcode {
 	 * Get the TLD from the URL
 	 */
 	private static function get_tld_from_url( $url ) {
-		$domain = parse_url( $url, PHP_URL_HOST );
+		$domain = self::parse_url( $url, PHP_URL_HOST );
 		if ( empty( $domain ) ) {
 			return '';
 		}

--- a/inc/shortcodes/class-soundcloud.php
+++ b/inc/shortcodes/class-soundcloud.php
@@ -42,11 +42,11 @@ class SoundCloud extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( 'w.soundcloud.com' !== parse_url( $iframe->src_force_protocol, PHP_URL_HOST ) ) {
+				if ( 'w.soundcloud.com' !== self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ) ) {
 					continue;
 				}
 				// Track ID is exposed in the `url` parameter
-				$query = parse_url( $iframe->src_force_protocol, PHP_URL_QUERY );
+				$query = self::parse_url( $iframe->attrs['src'], PHP_URL_QUERY );
 				$query = str_replace( '&amp;', '&', $query );
 				parse_str( $query, $args );
 				if ( empty( $args['url'] ) ) {

--- a/inc/shortcodes/class-videoo.php
+++ b/inc/shortcodes/class-videoo.php
@@ -55,10 +55,10 @@ EOT;
 		if ( $scripts = self::parse_scripts( $content ) ) {
 			$replacements = array();
 			foreach ( $scripts as $script ) {
-				if ( 'videoo.com' !== parse_url( $script->src_force_protocol, PHP_URL_HOST ) ) {
+				if ( 'videoo.com' !== self::parse_url( $script->attrs['src'], PHP_URL_HOST ) ) {
 					continue;
 				}
-				$path = parse_url( $script->src_force_protocol, PHP_URL_PATH );
+				$path = self::parse_url( $script->attrs['src'], PHP_URL_PATH );
 				$url = sprintf( 'https://videoo.com%s', $path );
 				$replacements[ $script->original ] = '[' . self::get_shortcode_tag() . ' url="' . esc_url_raw( $url ) . '"]';
 			}

--- a/inc/shortcodes/class-vimeo.php
+++ b/inc/shortcodes/class-vimeo.php
@@ -24,11 +24,11 @@ class Vimeo extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( 'player.vimeo.com' !== parse_url( $iframe->src_force_protocol, PHP_URL_HOST ) ) {
+				if ( 'player.vimeo.com' !== self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ) ) {
 					continue;
 				}
 				// Embed ID is the second part of the URL
-				$parts = explode( '/', trim( parse_url( $iframe->src_force_protocol, PHP_URL_PATH ), '/' ) );
+				$parts = explode( '/', trim( self::parse_url( $iframe->attrs['src'], PHP_URL_PATH ), '/' ) );
 				if ( empty( $parts[1] ) ) {
 					continue;
 				}
@@ -44,7 +44,7 @@ class Vimeo extends Shortcode {
 	public static function callback( $attrs, $content = '' ) {
 
 		$valid_hosts = array( 'www.vimeo.com', 'vimeo.com' );
-		$host = parse_url( $attrs['url'], PHP_URL_HOST );
+		$host = self::parse_url( $attrs['url'], PHP_URL_HOST );
 		if ( empty( $attrs['url'] ) || ! in_array( $host, $valid_hosts ) ) {
 			return '';
 		}

--- a/inc/shortcodes/class-vine.php
+++ b/inc/shortcodes/class-vine.php
@@ -42,17 +42,17 @@ class Vine extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( 'vine.co' !== parse_url( $iframe->src_force_protocol, PHP_URL_HOST ) ) {
+				if ( 'vine.co' !== self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ) ) {
 					continue;
 				}
-				if ( preg_match( '#//vine.co/v/([^/]+)/embed/(simple|postcard)#', $iframe->src_force_protocol, $matches ) ) {
+				if ( preg_match( '#//vine.co/v/([^/]+)/embed/(simple|postcard)#', $iframe->attrs['src'], $matches ) ) {
 					$embed_id = $matches[1];
 					$type = $matches[2];
 				} else {
 					continue;
 				}
 				$replacement_url = 'https://vine.co/v/' . $embed_id;
-				if ( false !== stripos( $iframe->src_force_protocol, '?audio=1' ) ) {
+				if ( false !== stripos( $iframe->attrs['src'], '?audio=1' ) ) {
 					$autoplay = ' autoplay="1"';
 				} else {
 					$autoplay = '';
@@ -67,7 +67,7 @@ class Vine extends Shortcode {
 
 	public static function callback( $attrs, $content = '' ) {
 
-		if ( empty( $attrs['url'] ) || 'vine.co' !== parse_url( $attrs['url'], PHP_URL_HOST ) ) {
+		if ( empty( $attrs['url'] ) || 'vine.co' !== self::parse_url( $attrs['url'], PHP_URL_HOST ) ) {
 			return '';
 		}
 

--- a/inc/shortcodes/class-youtube.php
+++ b/inc/shortcodes/class-youtube.php
@@ -26,10 +26,10 @@ class YouTube extends Shortcode {
 		if ( $iframes = self::parse_iframes( $content ) ) {
 			$replacements = array();
 			foreach ( $iframes as $iframe ) {
-				if ( ! in_array( parse_url( $iframe->src_force_protocol, PHP_URL_HOST ), self::$valid_hosts ) ) {
+				if ( ! in_array( self::parse_url( $iframe->attrs['src'], PHP_URL_HOST ), self::$valid_hosts ) ) {
 					continue;
 				}
-				if ( preg_match( '#youtube\.com/embed/([^/?]+)#', $iframe->src_force_protocol, $matches ) ) {
+				if ( preg_match( '#youtube\.com/embed/([^/?]+)#', $iframe->attrs['src'], $matches ) ) {
 					$embed_id = $matches[1];
 				} else {
 					continue;
@@ -45,7 +45,7 @@ class YouTube extends Shortcode {
 
 	public static function callback( $attrs, $content = '' ) {
 
-		$host = parse_url( $attrs['url'], PHP_URL_HOST );
+		$host = self::parse_url( $attrs['url'], PHP_URL_HOST );
 		if ( empty( $attrs['url'] ) || ! in_array( $host, self::$valid_hosts ) ) {
 			return '';
 		}
@@ -54,7 +54,7 @@ class YouTube extends Shortcode {
 
 		// https://www.youtube.com/watch?v=hDlpVFDmXrc
 		if ( in_array( $host, self::$valid_hosts ) ) {
-			$query = str_replace( '&amp;', '&', parse_url( $attrs['url'], PHP_URL_QUERY ) );
+			$query = str_replace( '&amp;', '&', self::parse_url( $attrs['url'], PHP_URL_QUERY ) );
 			parse_str( $query, $args );
 			if ( empty( $args['v'] ) ) {
 				return '';

--- a/tests/class-shortcode.php
+++ b/tests/class-shortcode.php
@@ -14,4 +14,8 @@ class Shortcode extends Shortcake_Bakery\Shortcodes\Shortcode {
 		return parent::make_replacements_to_content( $content, $replacements );
 	}
 
+	public static function parse_url( $url, $component = -1 ) {
+		return parent::parse_url( $url, $component );
+	}
+
 }

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -22,7 +22,6 @@ EOT;
 		$first_iframe->before = '';
 		$first_iframe->after = '';
 		$first_iframe->inner = '';
-		$first_iframe->src_force_protocol = 'http://foo.com';
 		$first_iframe->attrs = array(
 			'src'             => 'http://foo.com',
 			'allowfullscreen' => null,
@@ -33,7 +32,6 @@ EOT;
 		$second_iframe->before = '';
 		$second_iframe->after = '';
 		$second_iframe->inner = '';
-		$second_iframe->src_force_protocol = 'http://bar.com';
 		$second_iframe->attrs = array(
 			'src'             => 'http://bar.com',
 			);
@@ -48,7 +46,6 @@ EOT;
 		$iframe_obj->before = '';
 		$iframe_obj->after = '';
 		$iframe_obj->inner = '';
-		$iframe_obj->src_force_protocol = 'http://foo.com';
 		$iframe_obj->attrs = array(
 			'src'             => 'http://foo.com',
 			'bar'             => 'apple',
@@ -70,7 +67,6 @@ EOT;
 		$iframe_obj->before = '';
 		$iframe_obj->after = '<p><a href="http://giphy.com/gifs/jtvedit-jtv-rogelio-de-la-vega-ihfrhIgdkQ83C">via GIPHY</a></p>';
 		$iframe_obj->inner = '';
-		$iframe_obj->src_force_protocol = 'http://giphy.com/embed/ihfrhIgdkQ83C';
 		$iframe_obj->attrs = array(
 			'src'             => '//giphy.com/embed/ihfrhIgdkQ83C',
 			'width'           => '480',
@@ -88,7 +84,6 @@ EOT;
 		$iframe_obj->before = '';
 		$iframe_obj->after = '';
 		$iframe_obj->inner = 'Why is there text in here?';
-		$iframe_obj->src_force_protocol = 'http://foo.com';
 		$iframe_obj->attrs = array(
 			'src'             => 'http://foo.com',
 			);
@@ -104,7 +99,6 @@ EOT;
 			'before' => '<div id="wsd-root"></div>' . "\r\n",
 			'after' => '',
 			'inner' => '',
-			'src_force_protocol' => 'http://script-domain.net/assets/js/widget.js?id=3',
 			'attrs' => array(
 				'type' => 'text/javascript',
 				'src' => 'http://script-domain.net/assets/js/widget.js?id=3',
@@ -135,6 +129,15 @@ EOT;
 	public function test_no_make_replacements_to_content() {
 		$iframe_str = '<iframe src="http://foo.com">Why is there text in here?</iframe>';
 		$this->assertEquals( $iframe_str, Shortcode::make_replacements_to_content( $iframe_str, array() ) );
+	}
+
+	public function test_parse_url() {
+		$this->assertEquals( 'apple.com', Shortcode::parse_url( '//apple.com/foo', PHP_URL_HOST ) );
+		$this->assertEquals( '/foo', Shortcode::parse_url( '//apple.com/foo', PHP_URL_PATH ) );
+		$this->assertEquals( array(
+			'host'           => 'apple.com',
+			'path'           => '/foo',
+		), Shortcode::parse_url( '//apple.com/foo' ) );
 	}
 
 }

--- a/tests/test-silk-shortcode.php
+++ b/tests/test-silk-shortcode.php
@@ -39,7 +39,7 @@ EOT;
 
 		apples before
 
-		[silk url="http://us-states-with-hiv-specific-criminal-laws.silk.co/s/embed/map/collection/states-with-hiv-specific-criminal-laws-1/location/title/on/silk.co/order/asc/states-with-hiv-specific-criminal-law"]
+		[silk url="//us-states-with-hiv-specific-criminal-laws.silk.co/s/embed/map/collection/states-with-hiv-specific-criminal-laws-1/location/title/on/silk.co/order/asc/states-with-hiv-specific-criminal-law"]
 
 		bananas after
 EOT;


### PR DESCRIPTION
The original problem to be solved was `parse_url()`'s lack of protocol-less URL support in PHP 5.3

Let's solve this specific problem, instead of half-solving it and introducing a new problem where the wrong protocol can be specified.